### PR TITLE
PR 12: added npm run start:dev:win to script in package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "posttest": "npm run lint && nsp check --output writefile",
     "build": "./node_modules/.bin/babel src -s -D -d dist --ignore node_modules",
     "start:dev": "./node_modules/.bin/nodemon --exec ./node_modules/.bin/babel-node ./src/server/server.js",
+    "start:dev:win" : ".\\node_modules\\.bin\\nodemon --exec .\\node_modules\\.bin\\babel-node .\\src\\server\\server.js",
     "start:production": "npm run build && pm2-docker start ./dist/server/server.js",
     "lint": "./node_modules/.bin/eslint . -c .eslintrc ./src/ --ignore-pattern ./dist/",
     "test": "./node_modules/.bin/babel-node ./node_modules/.bin/cross-env NODE_ENV=test ./node_modules/.bin/nyc ./node_modules/.bin/mocha --recursive tests/",


### PR DESCRIPTION
# Pull Request

**Github Issue Number Link:** [*Github Issue 12*](https://github.com/PLMCSIT/PLMAT-API/issues/12)

**GitHub Branch Link:** [*GitHub Branch 12*](https://github.com/eljhtrstn99/PLMAT-API/tree/Issue_12)

## Description
- *provided an additional script to enable npm run start:dev for Windows*

## Changes
- *added npm run start:dev:win to script in package.json*

## Place to start
- *run `npm run start:dev:win`*